### PR TITLE
Updated URL for API interaction

### DIFF
--- a/src/main/java/org/brunocvcunha/opennode/api/OpenNodeServiceFactory.java
+++ b/src/main/java/org/brunocvcunha/opennode/api/OpenNodeServiceFactory.java
@@ -31,7 +31,7 @@ import retrofit2.converter.gson.GsonConverterFactory;
  */
 public class OpenNodeServiceFactory {
 
-    private static final String BASE_URL_V1 = "https://api.opennode.co/v1/";
+    private static final String BASE_URL_V1 = "https://api.opennode.com/v1/";
 
     public static OpenNodeService buildClient(String accessToken) {
         OkHttpClient httpClient = createClientInterceptor(accessToken);


### PR DESCRIPTION
updated deprecated url to: 
https://api.opennode.com/v1/